### PR TITLE
Modify regex in TestTaskTwo.testSqlQuery() and TestTaskFour.testSqlQuery()

### DIFF
--- a/src/test/java/org/launchcode/techjobs/persistent/TestTaskFour.java
+++ b/src/test/java/org/launchcode/techjobs/persistent/TestTaskFour.java
@@ -217,9 +217,10 @@ public class TestTaskFour extends AbstractTest {
     public void testSqlQuery () throws IOException {
         String queryFileContents = getFileContents("queries.sql");
 
-        Pattern queryPattern = Pattern.compile("SELECT\\s+\\*\\s+FROM\\s+skill" +
-                "\\s*(LEFT|INNER)?\\s+JOIN\\s+job_skills\\s+ON\\s+(skill.id\\s+=\\s+job_skills.skills_id|job_skills.skills_id\\s+=\\s+skill.id)" +
-                "(\\s*WHERE\\s+job_skills.jobs_id\\s+IS\\s+NOT\\s+NULL)?" +
+        Pattern queryPattern = Pattern.compile("(?=[^()]*(\\([^()]+\\)[^()]*)*$)" +
+                "SELECT\\s+\\*\\s+FROM\\s+skill" +
+                "\\s*(LEFT|INNER)?\\s+JOIN\\s+job_skills\\s+ON\\s+\\(?(skill.id\\s*=\\s*job_skills.skills_id|job_skills.skills_id\\s*=\\s*skill.id)\\)?" +
+                "(\\s*WHERE\\s+\\(?job_skills.jobs_id\\s+IS\\s+NOT\\s+NULL\\)?)?" +
                 "\\s*ORDER\\s+BY\\s+name\\s+ASC;", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
         Matcher queryMatcher = queryPattern.matcher(queryFileContents);
         boolean queryFound = queryMatcher.find();

--- a/src/test/java/org/launchcode/techjobs/persistent/TestTaskTwo.java
+++ b/src/test/java/org/launchcode/techjobs/persistent/TestTaskTwo.java
@@ -548,7 +548,7 @@ public class TestTaskTwo extends AbstractTest {
 //    public void testSqlQuery() throws IOException {
 //        String queryFileContents = getFileContents("queries.sql");
 //
-//        Pattern queryPattern = Pattern.compile("SELECT\\s+name\\s+FROM\\s+employer\\s+WHERE\\s+location\\s+=\\s+\"St.\\s+Louis\\s+City\";", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+//        Pattern queryPattern = Pattern.compile("SELECT\\s+name\\s+FROM\\s+employer\\s+WHERE\\s+location\\s*=\\s*\"St.\\s+Louis\\s+City\";", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 //        Matcher queryMatcher = queryPattern.matcher(queryFileContents);
 //        boolean queryFound = queryMatcher.find();
 //        assertTrue(queryFound, "Task 2 SQL query is incorrect. Test your query against your database to find the error.");


### PR DESCRIPTION
to allow for no whitespace before and after ='s.

Also permit parenthesis for some clauses (if matched) in TestTaskFour.testSqlQuery().